### PR TITLE
Tgates/db 30412

### DIFF
--- a/scripts/ci/test_operator.sh
+++ b/scripts/ci/test_operator.sh
@@ -18,7 +18,7 @@ kubectl create namespace $OPERATOR_NAMESPACE
 kubectl create secret docker-registry regcred --namespace=nuodb --docker-server=$DOCKER_SERVER --docker-username=$BOT_U --docker-password=$BOT_P --docker-email=""
 
 echo "Start of Operator GoLang e2e test"
-operator-sdk test local ./test/e2e --namespace $OPERATOR_NAMESPACE --verbose --kubeconfig $HOME/.kube/config --image $NUODB_OP_IMAGE --go-test-flags "-short"
+operator-sdk test local ./test/e2e --namespace $OPERATOR_NAMESPACE --debug --verbose --kubeconfig $HOME/.kube/config --image $NUODB_OP_IMAGE --go-test-flags "-short"
 echo "End of Operator GoLang e2e test"
 
 

--- a/test/e2e/util/cluster.go
+++ b/test/e2e/util/cluster.go
@@ -110,6 +110,7 @@ func SetupOperator(t *testing.T, ctx *framework.TestCtx) {
 
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "nuodb-operator", 1, RetryInterval, Timeout)
 	assert.NilError(t, err)
+	time.Sleep(time.Second * 5) // Temporary workaround until the root cause of DB-30412 is found.
 }
 
 // DeployNuodbAdmin creates a custom resource and checks if the

--- a/test/e2e/util/cluster.go
+++ b/test/e2e/util/cluster.go
@@ -3,6 +3,7 @@ package util
 import (
 	goctx "context"
 	"flag"
+	"nuodb/nuodb-operator/pkg/trace"
 	"testing"
 	"time"
 	"gotest.tools/assert"
@@ -117,6 +118,9 @@ func DeployNuodbAdmin(t *testing.T, ctx *framework.TestCtx, nuodbAdmin *nuodb.Nu
 	f := framework.Global
 
 	err := f.Client.Create(goctx.TODO(), nuodbAdmin, &framework.CleanupOptions{TestContext: ctx, Timeout: CleanupTimeout, RetryInterval: CleanupRetryInterval})
+	if err != nil {
+		t.Log(trace.Wrap(err))
+	}
 	assert.NilError(t, err)
 
 	err = WaitForStatefulSet(t, f.KubeClient, nuodbAdmin.Namespace, "admin", 1, RetryInterval, StatefulSetTimeout)


### PR DESCRIPTION
Temporary workaround race condition in the opeator-sdk e2e test.

This is needed to keep builds green so that DB-30412 will not block other PRs.
