### PR TITLE
Make sure doc check gets a valid commit range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,10 @@ env:
 
 before_install:
   - |
-    set -e
-    # fail loudly when force-pushed
-    MODIFIED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+    BASE_COMMIT=$(git merge-base HEAD master)
+    MODIFIED_FILES=$(git diff --name-only "${BASE_COMMIT}")
     # waiting for native solution https://github.com/travis-ci/travis-ci/issues/6301
-    if [ -z "${MODIFIED_FILES}" ]; then
-      # $TRAVIS_COMMIT_RANGE will be empty for builds triggered by the initial commit of a new branch.
-      echo "No changes found, can not determine what to skip"
-    elif ! echo ${MODIFIED_FILES} | grep -qvE '(\.md$)'; then
+    if ! echo "${MODIFIED_FILES}" | grep -qvE '(\.md$)'; then
       echo "Only docs were updated, stopping build process."
       exit
     fi


### PR DESCRIPTION
On force pushes, the environment variable TRAVIS_COMMIT_RANGE will have
a non-existent SHA as its first commit, causing the doc check to fail.
This changes the doc check to take the diff of the branch against master
at the point it branched off.